### PR TITLE
Add `GridLayer` class

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ extension.
 
 ## List of plugins
 
-| Plugin              | Short description                                | Depends on                                   |
-| ------------------- | ------------------------------------------------ | -------------------------------------------- |
-| GDScript Transpiler | Adds an editor interface for transpiling scripts | `gdscript_transpiler` module (experimental). |
+|        Plugin        |                 Short description                 |                 Depends on                  |
+| -------------------- | ------------------------------------------------- | ------------------------------------------- |
+| `GridLayer`          | Displays infinite grid at run-time.               | `GridRect` class                            |
+| `GDScriptTranspiler` | Adds an editor interface for transpiling scripts. | `gdscript_transpiler` module (experimental) |
 
 ## Compatibility
 

--- a/addons/grid_layer/grid_layer.gd
+++ b/addons/grid_layer/grid_layer.gd
@@ -1,0 +1,62 @@
+class_name GridLayer, "icon_grid_layer.svg" extends CanvasLayer
+tool
+
+# This class allows to display infinite grid at run-time, similarly to how
+# editor displays grid with snapping is enabled in canvas editor.
+# For example, when using Camera2D, the grid's origin offset and scale are
+# going to be updated automatically.
+
+func _init():
+	 # Do not show grid on top, since we have transparent grid by default.
+	layer = -1
+
+
+func _ready():
+	if not Engine.editor_hint:
+		return
+
+	# Instantiate a default GridRect with transparent background.
+	var grid = GridRect.new()
+	add_child(grid)
+	if get_parent():
+		if get_parent().filename:
+			grid.owner = get_parent()
+		else:
+			grid.owner = get_parent().owner
+
+	grid.origin_axes_visible = true
+
+	grid.anchor_right = 1.0
+	grid.anchor_bottom = 1.0
+	grid.margin_right = 0.0
+	grid.margin_bottom = 0.0
+
+	var bc = Color()
+	bc.a = 0.0 # Transparent by default.
+	grid.set("custom_colors/background", bc)
+	# Use default colors from GraphEdit.
+	grid.set("custom_colors/line_cell", grid.get_color("grid_minor", "GraphEdit"))
+	grid.set("custom_colors/line_division", grid.get_color("grid_major", "GraphEdit"))
+
+
+func _process(_delta):
+	for idx in get_child_count():
+		var grid = get_child(idx)
+		if not grid is GridRect:
+			continue
+
+		grid.origin_offset = get_viewport().canvas_transform.origin
+		grid.origin_scale = get_viewport().canvas_transform.get_scale()
+
+
+func _get_configuration_warning():
+	if not has_grid():
+		return "GridLayer must have at least one GridRect added as a child."
+	return ""
+
+
+func has_grid():
+	for idx in get_child_count():
+		if get_child(idx) is GridRect:
+			return true
+	return false

--- a/addons/grid_layer/grid_layer_plugin.gd
+++ b/addons/grid_layer/grid_layer_plugin.gd
@@ -1,0 +1,2 @@
+tool
+extends EditorPlugin

--- a/addons/grid_layer/icon_grid_layer.svg
+++ b/addons/grid_layer/icon_grid_layer.svg
@@ -1,0 +1,1 @@
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><ellipse cx="3" cy="3" fill="#6e6e6e"/><g fill="#dedede"><path d="m1 1h14v.999976h-14z"/><path d="m1 7.5h14v.999992h-14z"/><path d="m1 14h14v1.000024h-14z"/><path d="m1 1h1v14.000025h-1z"/><path d="m7.5 1h1v14.00005h-1z"/><path d="m14 1h1v13.999975h-1z"/></g></svg>

--- a/addons/grid_layer/icon_grid_layer.svg.import
+++ b/addons/grid_layer/icon_grid_layer.svg.import
@@ -1,0 +1,34 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/icon_grid_layer.svg-4d36d2a91fa21a54de7ea7a412dae37f.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://addons/grid_layer/icon_grid_layer.svg"
+dest_files=[ "res://.import/icon_grid_layer.svg-4d36d2a91fa21a54de7ea7a412dae37f.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/addons/grid_layer/plugin.cfg
+++ b/addons/grid_layer/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="GridLayer"
+description="Display infinite grid at run-time"
+author="Goost"
+version="0.1"
+script="grid_layer_plugin.gd"

--- a/project.godot
+++ b/project.godot
@@ -13,9 +13,15 @@ _global_script_classes=[ {
 "class": "GoostImageTiling",
 "language": "GDScript",
 "path": "res://ports/image_tiling.gd"
+}, {
+"base": "CanvasLayer",
+"class": "GridLayer",
+"language": "GDScript",
+"path": "res://addons/grid_layer/grid_layer.gd"
 } ]
 _global_script_class_icons={
-"GoostImageTiling": ""
+"GoostImageTiling": "",
+"GridLayer": "res://addons/grid_layer/icon_grid_layer.svg"
 }
 
 [application]
@@ -25,4 +31,4 @@ config/icon="res://icon.png"
 
 [editor_plugins]
 
-enabled=PoolStringArray( "gdscript_transpiler" )
+enabled=PoolStringArray( "res://addons/grid_layer/plugin.cfg" )


### PR DESCRIPTION
Allows to display infinite grid at run-time. Useful for debugging purposes. This means that you can move `Camera2D` to any place, and grid will be automatically redrawn based on canvas transform.

![image](https://user-images.githubusercontent.com/17108460/133280802-e0be780b-bcb3-451a-8590-cb736e6b7747.png)

Simply add `GridLayer` node:

![image](https://user-images.githubusercontent.com/17108460/133281085-466fd5ad-3aee-41fa-bff3-ebf7256a96ca.png)

This requires `GridRect` node implemented in [Goost](https://goostengine.github.io/), which is instantiated automatically in the editor with default parameters useful for debugging/editing (with the same colors in Godot's canvas editor). You can also add multiple `GridRect`s, and all will be rendered alongside.
